### PR TITLE
Preliminary window function support

### DIFF
--- a/src/sqerl.erl
+++ b/src/sqerl.erl
@@ -289,8 +289,6 @@ extra_clause(Exprs, Safe) when is_list(Exprs) ->
                 throw({error, {unsafe_expression, Exprs}})
             end
     end;
-extra_clause(Exprs, true) when is_list(Exprs) ->
-    extra_clause2(Exprs, true);
 extra_clause({limit, Num}, _Safe) ->
     [<<"LIMIT ">>, encode(Num)];
 extra_clause({limit, Offset, Num}, _Safe) ->

--- a/test/sqerl_tests.erl
+++ b/test/sqerl_tests.erl
@@ -340,6 +340,15 @@ unsafe_test_() ->
 
             {<<"SELECT row_number() OVER (ORDER BY foo DESC), bar FROM baz">>,
              ?_unsafe_test({select, [{over, {call, row_number, []}, {order_by, [{foo, desc}]}}, bar], {from, baz}})
+            },
+
+            {<<"SELECT row_number() OVER (PARTITION BY foo, bar ORDER BY foo DESC), bar FROM baz">>,
+             ?_unsafe_test({select, [{over, {call, row_number, []}, [{partition_by, [foo, bar]}, {order_by, {foo, desc}}]}, bar], {from, baz}})
+            },
+
+            {<<"SELECT rank() FILTER (WHERE foo >= 2) OVER (PARTITION BY bar) FROM baz">>,
+             ?_unsafe_test({select, [{over, {call, rank, []}, "foo >= 2", {partition_by, bar}}], {from, baz}})
             }
+
         ]
     }.

--- a/test/sqerl_tests.erl
+++ b/test/sqerl_tests.erl
@@ -336,6 +336,10 @@ unsafe_test_() ->
 
             {<<"SELECT NOT (foo = bar)">>,
                 ?_unsafe_test({select,{'!',"foo = bar"}})
+            },
+
+            {<<"SELECT row_number() OVER (ORDER BY foo DESC), bar FROM baz">>,
+             ?_unsafe_test({select, [{over, {call, row_number, []}, {order_by, [{foo, desc}]}}, bar], {from, baz}})
             }
         ]
     }.


### PR DESCRIPTION
Introduce limited support for Window functions defined by http://www.postgresql.org/docs/9.4/static/sql-expressions.html#SYNTAX-WINDOW-FUNCTIONS

This PR aims to allow support for the `win_fun() FILTER (WHERE filter_clause) OVER (...)` where the contents of the parenthesis after `OVER` can be (a group of) `PARTITION BY` and `ORDER BY` statements.

In other words, there's no support for range expressions nor named windows. This might come at a later point.