### PR TITLE
Support sub SELECTs

### DIFF
--- a/src/sqerl.erl
+++ b/src/sqerl.erl
@@ -406,6 +406,18 @@ expr({call, FuncName, []}, _Safe) ->
     [convert(FuncName), <<"()">>];
 expr({call, FuncName, Params}, _Safe) ->
     [convert(FuncName), $(, make_list(Params, fun param/1), $)];
+expr({select, _} = Subquery, Safe) ->
+    [$(, sql2(Subquery, Safe), $) ];
+expr({select, _, _} = Subquery, Safe) ->
+    [$(, sql2(Subquery, Safe), $)];
+expr({select, _, _, _} = Subquery, Safe) ->
+    [$(, sql2(Subquery, Safe), $)];
+expr({select, _, _, _, _} = Subquery, Safe) ->
+    [$(, sql2(Subquery, Safe), $)];
+expr({select, _, _, _, _, _} = Subquery, Safe) ->
+    [$(, sql2(Subquery, Safe), $)];
+expr({select, _, _, _, _, _, _} = Subquery, Safe) ->
+    [$(, sql2(Subquery, Safe), $)];
 expr({Val, Op, {select, _} = Subquery}, Safe) ->
     subquery(Val, Op, Subquery, Safe);
 expr({Val, Op, {select, _, _} = Subquery}, Safe) ->

--- a/test/sqerl_tests.erl
+++ b/test/sqerl_tests.erl
@@ -336,6 +336,10 @@ unsafe_test_() ->
 
             {<<"SELECT NOT (foo = bar)">>,
                 ?_unsafe_test({select,{'!',"foo = bar"}})
+            },
+
+            {<<"SELECT foo FROM (SELECT foo FROM bar) AS baz">>,
+             ?_unsafe_test({select, [foo], {from, {{select, [foo], {from, bar}}, as, baz}}})
             }
         ]
     }.


### PR DESCRIPTION
Introduce support for sub SELECTs on the form of `SELECT * FROM (SELECT ...) AS foo`